### PR TITLE
Feat page my recipes show data

### DIFF
--- a/src/api/noteApi.js
+++ b/src/api/noteApi.js
@@ -5,6 +5,11 @@ export const getNotes = async () => {
   return response.data;
 };
 
+export const getNotesByUserId = async (userId) => {
+  const response = await fetchApi.get(`/api/notes/${userId}`);
+  return response.data;
+};
+
 export const createNote = async (note) => {
   const response = await fetchApi.post("/api/notes", note);
   return response.data;

--- a/src/components/Card.Recipe.js
+++ b/src/components/Card.Recipe.js
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 
 const RecipeCard = ({ recipeData }) => {
-  const { thumbnailUrl: videoThumbnail, like, dislike } = recipeData;
+  const { thumbnailUrl: videoThumbnail, liked, disliked } = recipeData;
   const { thumbnailUrl: userThumbnail, nickname } = recipeData.postedBy;
   const menuName = recipeData.belongsToMenu.name;
 
@@ -12,8 +12,8 @@ const RecipeCard = ({ recipeData }) => {
         <MenuName>{menuName}</MenuName>
         <PostingOwner>{nickname}</PostingOwner>
         <RecipePreference>
-          <div>👍 {like}</div>
-          <div>👎 {dislike}</div>
+          <div>👍 {liked.length}</div>
+          <div>👎 {disliked.length}</div>
         </RecipePreference>
       </RecipeInfoBox>
     </Container>
@@ -32,7 +32,7 @@ const Container = styled.div`
 
 const VideoThumbnail = styled.img`
   width: 100%;
-  border-radius: 10px;
+  border-radius: 10px 10px 0px 0px;
 `;
 
 const RecipeInfoBox = styled.div`

--- a/src/components/Loading.js
+++ b/src/components/Loading.js
@@ -1,0 +1,37 @@
+import styled from "styled-components";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faSpinner } from "@fortawesome/free-solid-svg-icons";
+
+function Loading() {
+  return (
+    <LoadingContainer>
+      <FontAwesomeIcon icon={faSpinner} size="8x" />
+      <div>데이터 로딩중...</div>
+    </LoadingContainer>
+  );
+}
+
+export default Loading;
+
+const LoadingContainer = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  padding-top: 80px;
+  padding-bottom: 100px;
+  justify-content: center;
+  align-items: center;
+
+  svg {
+    animation-duration: 2s;
+    animation-name: rotate;
+    animation-iteration-count: infinite;
+    margin-bottom: 20px;
+  }
+
+  div {
+    font-size: large;
+    font-weight: bold;
+  }
+`;

--- a/src/index.css
+++ b/src/index.css
@@ -13,3 +13,16 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
+
+@keyframes rotate {
+  from {
+    -webkit-transform: rotate(0deg);
+    -o-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  to {
+    -webkit-transform: rotate(360deg);
+    -o-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}

--- a/src/pages/PageMyRecipes.NoteCard.js
+++ b/src/pages/PageMyRecipes.NoteCard.js
@@ -1,0 +1,85 @@
+import styled from "styled-components";
+import { Fragment } from "react";
+import { Link } from "react-router-dom";
+
+const NoteCard = ({ noteData }) => {
+  const menuName = noteData.relatedRecipe.belongsToMenu.name;
+  const {
+    thumbnailUrl: videoThumbnail,
+    liked,
+    disliked,
+  } = noteData.relatedRecipe;
+  const recipeId = noteData.relatedRecipe._id;
+
+  return (
+    <Fragment>
+      <StyledLink to={`/recipes/${recipeId}`}>
+        <StyledLinkImg src={videoThumbnail} alt="recipe-thumbnail-image" />
+        <StyledLinkInfo>
+          <MenuName>{menuName}</MenuName>
+          <RecipePreference>
+            <div>👍 {liked.length}</div>
+            <div>👎 {disliked.length}</div>
+          </RecipePreference>
+        </StyledLinkInfo>
+      </StyledLink>
+    </Fragment>
+  );
+};
+
+export default NoteCard;
+
+const StyledLink = styled(Link)`
+  display: block;
+  width: 100%;
+  height: 100%;
+
+  background-color: white;
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+
+  &:hover {
+    border: 2px solid black;
+    padding: 2px;
+    font-weight: bolder;
+  }
+`;
+
+const StyledLinkImg = styled.img`
+  width: 100%;
+  height: 75%;
+  border-radius: 10px 10px 0px 0px;
+  background-color: gold;
+`;
+
+const StyledLinkInfo = styled.div`
+  height: 25%;
+  width: 100%;
+  min-height: 20px;
+  display: flex;
+  justify-content: space-around;
+  font-size: 16px;
+  align-items: center;
+`;
+
+const MenuName = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: medium;
+`;
+
+const RecipePreference = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: large;
+  width: 50%;
+
+  div {
+    margin: 0px 5px;
+  }
+`;

--- a/src/pages/PageMyRecipes.js
+++ b/src/pages/PageMyRecipes.js
@@ -1,12 +1,12 @@
 import { useEffect, useState, Fragment } from "react";
 import styled from "styled-components";
-import { Link } from "react-router-dom";
 import { getUser } from "../api/authApi";
 import { getNotesByUserId } from "../api/noteApi";
 
 import Header from "../components/Header";
 import Footer from "../components/Footer";
-import RecipeCard from "../components/Card.Recipe";
+import NoteCard from "./PageMyRecipes.NoteCard";
+import Loading from "../components/Loading";
 
 function PageMyRecipes({ loginUserInfo, handleLogin }) {
   const [notesData, setNotesData] = useState(null);
@@ -28,44 +28,22 @@ function PageMyRecipes({ loginUserInfo, handleLogin }) {
     getMyNotesData();
   }, [email]);
 
-  //업데이트 날짜: notesData[i].updatedAt
-  //메뉴명 : notesData[i].relatedRecipe.belongsToMenu.name
-  //thumbnailUrl:  notesData[i].thumbnailUrl
-
-  const NoteCard = ({ noteData }) => {
-    const menuName = noteData.relatedRecipe.belongsToMenu.name;
-    const {
-      thumbnailUrl: videoThumbnail,
-      liked,
-      disliked,
-    } = noteData.relatedRecipe;
-    const recipeId = noteData.relatedRecipe._id;
-
-    return (
-      <Fragment>
-        <StyledLink to={`/recipes/${recipeId}`}>
-          <StyledLinkImg src={videoThumbnail} alt="recipe-thumbnail-image" />
-          <StyledLinkInfo>
-            <MenuName>{menuName}</MenuName>
-            <RecipePreference>
-              <div>👍 {liked.length}</div>
-              <div>👎 {disliked.length}</div>
-            </RecipePreference>
-          </StyledLinkInfo>
-        </StyledLink>
-      </Fragment>
-    );
-  };
-
   return (
     <Container>
       <Header loginUserInfo={loginUserInfo} handleLogin={handleLogin} />
-      <Main>
-        {notesData &&
-          notesData.map((noteData) => (
+      {!notesData && (
+        <Main>
+          <Loading />
+        </Main>
+      )}
+      {notesData && (
+        <GridMain>
+          {notesData.map((noteData) => (
             <NoteCard key={`notes-${noteData._id}`} noteData={noteData} />
           ))}
-      </Main>
+        </GridMain>
+      )}
+
       <Footer />
     </Container>
   );
@@ -79,7 +57,7 @@ const Container = styled.div`
   flex-direction: column;
 `;
 
-const Main = styled.main`
+const GridMain = styled.main`
   height: 100%;
   overflow: auto;
   padding-top: 80px;
@@ -90,57 +68,11 @@ const Main = styled.main`
   margin: 10px;
 `;
 
-const StyledLink = styled(Link)`
-  display: block;
+const Main = styled.main`
   width: 100%;
   height: 100%;
-
-  background-color: white;
-  border-radius: 10px;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  align-items: center;
-
-  &:hover {
-    border: 2px solid black;
-    padding: 2px;
-    font-weight: bolder;
-  }
-`;
-
-const StyledLinkImg = styled.img`
-  width: 100%;
-  height: 75%;
-  border-radius: 10px 10px 0px 0px;
-  background-color: gold;
-`;
-
-const StyledLinkInfo = styled.div`
-  height: 25%;
-  width: 100%;
-  min-height: 20px;
-  display: flex;
-  justify-content: space-around;
-  font-size: 16px;
-  align-items: center;
-`;
-
-const MenuName = styled.div`
+  padding-top: 80px;
   display: flex;
   justify-content: center;
   align-items: center;
-  font-size: medium;
-`;
-
-const RecipePreference = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  font-size: large;
-  width: 50%;
-
-  div {
-    margin: 0px 5px;
-  }
 `;

--- a/src/pages/PageMyRecipes.js
+++ b/src/pages/PageMyRecipes.js
@@ -1,32 +1,70 @@
-import { useEffect } from "react";
+import { useEffect, useState, Fragment } from "react";
 import styled from "styled-components";
 import { Link } from "react-router-dom";
+import { getUser } from "../api/authApi";
+import { getNotesByUserId } from "../api/noteApi";
 
 import Header from "../components/Header";
 import Footer from "../components/Footer";
 import RecipeCard from "../components/Card.Recipe";
 
 function PageMyRecipes({ loginUserInfo, handleLogin }) {
+  const [notesData, setNotesData] = useState(null);
+  const { email } = loginUserInfo;
+  console.log("notesData", notesData);
+
   useEffect(() => {
     document.title = "MyRecipes";
   }, []);
+
+  useEffect(() => {
+    async function getMyNotesData() {
+      const responseUserData = await getUser(email);
+      const userId = responseUserData.data._id;
+      const responseNotesData = await getNotesByUserId(userId);
+      setNotesData(responseNotesData);
+    }
+
+    getMyNotesData();
+  }, [email]);
+
+  //업데이트 날짜: notesData[i].updatedAt
+  //메뉴명 : notesData[i].relatedRecipe.belongsToMenu.name
+  //thumbnailUrl:  notesData[i].thumbnailUrl
+
+  const NoteCard = ({ noteData }) => {
+    const menuName = noteData.relatedRecipe.belongsToMenu.name;
+    const {
+      thumbnailUrl: videoThumbnail,
+      liked,
+      disliked,
+    } = noteData.relatedRecipe;
+    const recipeId = noteData.relatedRecipe._id;
+
+    return (
+      <Fragment>
+        <StyledLink to={`/recipes/${recipeId}`}>
+          <StyledLinkImg src={videoThumbnail} alt="recipe-thumbnail-image" />
+          <StyledLinkInfo>
+            <MenuName>{menuName}</MenuName>
+            <RecipePreference>
+              <div>👍 {liked.length}</div>
+              <div>👎 {disliked.length}</div>
+            </RecipePreference>
+          </StyledLinkInfo>
+        </StyledLink>
+      </Fragment>
+    );
+  };
 
   return (
     <Container>
       <Header loginUserInfo={loginUserInfo} handleLogin={handleLogin} />
       <Main>
-        <StyledLink to="/recipes">요기</StyledLink>
-        <StyledLink to="/recipes">요기2</StyledLink>
-        <StyledLink to="/recipes">요기3</StyledLink>
-        <StyledLink to="/recipes">요기4</StyledLink>
-        <StyledLink to="/recipes">요기5</StyledLink>
-        <StyledLink to="/recipes">요기6</StyledLink>
-        <StyledLink to="/recipes">요기7</StyledLink>
-        <StyledLink to="/recipes">요기8</StyledLink>
-        <StyledLink to="/recipes">요기9</StyledLink>
-        <StyledLink to="/recipes">요기10</StyledLink>
-        <StyledLink to="/recipes">요기11</StyledLink>
-        <StyledLink to="/recipes">요기12</StyledLink>
+        {notesData &&
+          notesData.map((noteData) => (
+            <NoteCard key={`notes-${noteData._id}`} noteData={noteData} />
+          ))}
       </Main>
       <Footer />
     </Container>
@@ -46,8 +84,8 @@ const Main = styled.main`
   overflow: auto;
   padding-top: 80px;
   display: grid;
-  grid-template-columns: repeat(8, 1fr);
-  grid-auto-rows: 250px;
+  grid-template-columns: repeat(6, 1fr);
+  grid-auto-rows: 150px;
   gap: 10px;
   margin: 10px;
 `;
@@ -61,12 +99,48 @@ const StyledLink = styled(Link)`
   border-radius: 10px;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: space-between;
   align-items: center;
 
   &:hover {
     border: 2px solid black;
     padding: 2px;
     font-weight: bolder;
+  }
+`;
+
+const StyledLinkImg = styled.img`
+  width: 100%;
+  height: 75%;
+  border-radius: 10px 10px 0px 0px;
+  background-color: gold;
+`;
+
+const StyledLinkInfo = styled.div`
+  height: 25%;
+  width: 100%;
+  min-height: 20px;
+  display: flex;
+  justify-content: space-around;
+  font-size: 16px;
+  align-items: center;
+`;
+
+const MenuName = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: medium;
+`;
+
+const RecipePreference = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: large;
+  width: 50%;
+
+  div {
+    margin: 0px 5px;
   }
 `;

--- a/src/pages/PageMyRecipes.js
+++ b/src/pages/PageMyRecipes.js
@@ -11,7 +11,6 @@ import Loading from "../components/Loading";
 function PageMyRecipes({ loginUserInfo, handleLogin }) {
   const [notesData, setNotesData] = useState(null);
   const { email } = loginUserInfo;
-  console.log("notesData", notesData);
 
   useEffect(() => {
     document.title = "MyRecipes";


### PR DESCRIPTION
## What is this PR? 🔍
- My Recipe 화면에서 내가 작성한 노트가 있는 레시피 영상 목록을 보여줍니다.
- 마이레시피 화면에서 내가 작성한 노트가 있는 레시피 영상만 보여주려고 하다보니 백엔드에서 double populate하는 상황이 발생하였습니다. 논의 가 필요합니다. 
   - (의견)추후에 랭킹페이지에서도 메뉴 중심으로 순위를 보여줄때 같은 상황이 발생할 것으로 예상됩니다.
 
- 리액트 쿼리를 사용하여 비동기 데이터를 받아 올 수 있게 리팩토링 필요합니다.(아직 리액트 쿼리가 미숙해서 시도했으나 실패하여 일단 현재 로직으로 작성을 완료 하였습니다.)

## Changes 📝
- PageMyRecipe.js 로직을 작성하였습니다.
- PageMyRecipes.NoteCard 컴포넌트를 추가하였습니다.
- noteApi에서 getNotesByUserId 함수를 추가하였습니다.
## Screennshot 📷
<img width="728" alt="image" src="https://user-images.githubusercontent.com/78262571/173173885-d6a6cb2f-0e48-429f-a918-0d6bfc0fac2f.png">

## Test Checklist ✅
- 내 아이디를 기준으로 노트가 불러오는지 테스트 요망.