### PR TITLE
feat: like recipe note tip

### DIFF
--- a/src/api/noteApi.js
+++ b/src/api/noteApi.js
@@ -5,6 +5,11 @@ export const getNotes = async () => {
   return response.data;
 };
 
+export const getNote = async (note_id) => {
+  const response = await fetchApi.get(`/api/notes/${note_id}`, note_id);
+  return response.data;
+};
+
 export const getMyNotes = async (userId) => {
   const response = await fetchApi.get(`/api/users/${userId}/notes`);
   return response.data;
@@ -17,6 +22,22 @@ export const createNote = async (note) => {
 
 export const updateNote = async (note) => {
   const response = await fetchApi.patch(`/api/notes/${note._id}`, note);
+  return response.data;
+};
+
+export const updateNoteLike = async (note) => {
+  const response = await fetchApi.patch(
+    `/api/notes/${note.note_id}/likes`,
+    note
+  );
+  return response.data;
+};
+
+export const cancelNoteLike = async (note) => {
+  const response = await fetchApi.patch(
+    `/api/notes/${note.note_id}/unlikes`,
+    note
+  );
   return response.data;
 };
 

--- a/src/api/recipeApi.js
+++ b/src/api/recipeApi.js
@@ -14,3 +14,19 @@ export const createRecipe = async (newRecipe) => {
   const response = await fetchApi.post("/api/recipes/new", newRecipe);
   return response.data;
 };
+
+export const updateRecipeLike = async (recipe) => {
+  const response = await fetchApi.patch(
+    `/api/recipes/${recipe.recipe_id}/likes`,
+    recipe
+  );
+  return response.data;
+};
+
+export const cancelRecipeLike = async (recipe) => {
+  const response = await fetchApi.patch(
+    `/api/recipes/${recipe.recipe_id}/unlikes`,
+    recipe
+  );
+  return response.data;
+};

--- a/src/api/tipApi.js
+++ b/src/api/tipApi.js
@@ -6,6 +6,12 @@ export const getTips = async () => {
   return response.data;
 };
 
+export const getTipsByRecipeId = async (recipe_id) => {
+  const response = await fetchApi.get(`/api/tips/${recipe_id}`);
+
+  return response.data;
+};
+
 export const createTip = async (tip) => {
   const response = await fetchApi.post("/api/tips", tip);
 
@@ -13,25 +19,25 @@ export const createTip = async (tip) => {
 };
 
 export const updateTip = async (tip) => {
-  const response = await fetchApi.patch(`/api/tip/${tip.id}`, tip);
+  const response = await fetchApi.patch(`/api/tips/${tip.id}`, tip);
 
   return response.data;
 };
 
 export const updateTipLike = async (tip) => {
-  const response = await fetchApi.patch(`/api/tip/${tip.id}/likes`, tip);
+  const response = await fetchApi.patch(`/api/tips/${tip.id}/likes`, tip);
 
   return response.data;
 };
 
 export const cancelTipLike = async (tip) => {
-  const response = await fetchApi.patch(`/api/tip/${tip.id}/unlikes`, tip);
+  const response = await fetchApi.patch(`/api/tips/${tip.id}/unlikes`, tip);
 
   return response.data;
 };
 
 export const deleteTip = async (tip_id) => {
-  const response = await fetchApi.delete(`/api/tip/${tip_id}`, tip_id);
+  const response = await fetchApi.delete(`/api/tips/${tip_id}`, tip_id);
 
   return response.data;
 };

--- a/src/hooks/note-mutation-hook.js
+++ b/src/hooks/note-mutation-hook.js
@@ -1,0 +1,52 @@
+import { useMutation, useQueryClient } from "react-query";
+import {
+  createNote,
+  updateNote,
+  deleteNote,
+  updateNoteLike,
+  cancelNoteLike,
+} from "../api/noteApi";
+
+const useNoteMutation = () => {
+  const queryClient = useQueryClient();
+
+  const createNoteMutation = useMutation(createNote, {
+    onSuccess: () => {
+      queryClient.invalidateQueries("recipe");
+    },
+  });
+
+  const updateNoteMutation = useMutation(updateNote, {
+    onSuccess: () => {
+      queryClient.invalidateQueries("recipe");
+    },
+  });
+
+  const deleteNoteMutation = useMutation(deleteNote, {
+    onSuccess: () => {
+      queryClient.invalidateQueries("recipe");
+    },
+  });
+
+  const updateNoteLikeMutation = useMutation(updateNoteLike, {
+    onSuccess: () => {
+      queryClient.invalidateQueries("recipe");
+    },
+  });
+
+  const cancelNoteLikeMutation = useMutation(cancelNoteLike, {
+    onSuccess: () => {
+      queryClient.invalidateQueries("recipe");
+    },
+  });
+
+  return {
+    createNoteMutation,
+    updateNoteMutation,
+    deleteNoteMutation,
+    updateNoteLikeMutation,
+    cancelNoteLikeMutation,
+  };
+};
+
+export default useNoteMutation;

--- a/src/hooks/recipe-mutation-hook.js
+++ b/src/hooks/recipe-mutation-hook.js
@@ -1,0 +1,36 @@
+import { useMutation, useQueryClient } from "react-query";
+import {
+  cancelRecipeLike,
+  createRecipe,
+  updateRecipeLike,
+} from "../api/recipeApi";
+
+const useRecipeMutation = () => {
+  const queryClient = useQueryClient();
+
+  const createRecipeMutation = useMutation(createRecipe, {
+    onSuccess: () => {
+      queryClient.invalidateQueries("recipe");
+    },
+  });
+
+  const updateRecipeLikeMutation = useMutation(updateRecipeLike, {
+    onSuccess: () => {
+      queryClient.invalidateQueries("recipe");
+    },
+  });
+
+  const cancelRecipeLikeMutation = useMutation(cancelRecipeLike, {
+    onSuccess: () => {
+      queryClient.invalidateQueries("recipe");
+    },
+  });
+
+  return {
+    createRecipeMutation,
+    updateRecipeLikeMutation,
+    cancelRecipeLikeMutation,
+  };
+};
+
+export default useRecipeMutation;

--- a/src/hooks/tip-mutation-hook.js
+++ b/src/hooks/tip-mutation-hook.js
@@ -1,0 +1,52 @@
+import { useMutation, useQueryClient } from "react-query";
+import {
+  cancelTipLike,
+  createTip,
+  deleteTip,
+  updateTip,
+  updateTipLike,
+} from "../api/tipApi";
+
+const useTipMutation = () => {
+  const queryClient = useQueryClient();
+
+  const createTipMutation = useMutation(createTip, {
+    onSuccess: () => {
+      queryClient.invalidateQueries("tips");
+    },
+  });
+
+  const updateTipMutation = useMutation(updateTip, {
+    onSuccess: () => {
+      queryClient.invalidateQueries("tips");
+    },
+  });
+
+  const deleteTipMutation = useMutation(deleteTip, {
+    onSuccess: () => {
+      queryClient.invalidateQueries("tips");
+    },
+  });
+
+  const updateTipLikeMutation = useMutation(updateTipLike, {
+    onSuccess: () => {
+      queryClient.invalidateQueries("tips");
+    },
+  });
+
+  const cancelTipLikeMutation = useMutation(cancelTipLike, {
+    onSuccess: () => {
+      queryClient.invalidateQueries("tips");
+    },
+  });
+
+  return {
+    createTipMutation,
+    updateTipMutation,
+    deleteTipMutation,
+    updateTipLikeMutation,
+    cancelTipLikeMutation,
+  };
+};
+
+export default useTipMutation;

--- a/src/pages/PageSingleRecipe.js
+++ b/src/pages/PageSingleRecipe.js
@@ -21,6 +21,7 @@ function PageSingleRecipe({ loginUserInfo, handleLogin }) {
   const { data: recipe } = useQuery(["recipe", recipe_id], () =>
     getRecipe(recipe_id)
   );
+
   const { updateRecipeLikeMutation, cancelRecipeLikeMutation } =
     useRecipeMutation();
 
@@ -82,6 +83,12 @@ function PageSingleRecipe({ loginUserInfo, handleLogin }) {
       <LeftSection>
         <NavigationPage>
           <StyledLinkButton to="/recipes">뒤로 가기</StyledLinkButton>
+          <button name="like" onClick={clickLikeHandler}>
+            👍 {recipe?.liked.length}
+          </button>
+          <button name="dislike" onClick={clickLikeHandler}>
+            👎 {recipe?.disliked.length}
+          </button>
         </NavigationPage>
         <VideoPlayer>
           <Screen>스크린</Screen>
@@ -103,12 +110,6 @@ function PageSingleRecipe({ loginUserInfo, handleLogin }) {
                 꿀팁
               </Button>
             </ButtonLeft>
-            <button name="like" onClick={clickLikeHandler}>
-              👍 {recipe?.liked.length}
-            </button>
-            <button name="dislike" onClick={clickLikeHandler}>
-              👎 {recipe?.disliked.length}
-            </button>
             <ButtonRight>
               {currentBoardPage !== "myNote" && (
                 <Button

--- a/src/utils/likeHelper.js
+++ b/src/utils/likeHelper.js
@@ -1,0 +1,6 @@
+export const isLikedCheck = (email, likedArray) => {
+  if (likedArray.includes(email)) {
+    return true;
+  }
+  return false;
+};

--- a/src/utils/sortHelper.js
+++ b/src/utils/sortHelper.js
@@ -2,10 +2,10 @@ exports.sortDescendingByUpdatedAt = (arrayData) => {
   const arrayDataCopy = arrayData.slice();
 
   arrayDataCopy.sort((a, b) => {
-    const updatedAtA = new Date(a.updatedAt).getTime();
-    const updatedAtB = new Date(b.updatedAt).getTime();
+    const updatedAtA = new Date(a.createdAt).getTime();
+    const updatedAtB = new Date(b.createdAt).getTime();
 
-    // return updatedAtA < updatedAtB ? -1 : updatedAtA > updatedAtB ? 1 : 0;
+    // return updatedAtA < updatedAtB ? 1 : updatedAtA > updatedAtB ? -1 : 0;
     return updatedAtB - updatedAtA;
   });
 

--- a/src/utils/sortHelper.js
+++ b/src/utils/sortHelper.js
@@ -5,7 +5,6 @@ exports.sortDescendingByUpdatedAt = (arrayData) => {
     const updatedAtA = new Date(a.createdAt).getTime();
     const updatedAtB = new Date(b.createdAt).getTime();
 
-    // return updatedAtA < updatedAtB ? 1 : updatedAtA > updatedAtB ? -1 : 0;
     return updatedAtB - updatedAtA;
   });
 


### PR DESCRIPTION
## What is this PR? 🔍
- 레시피, 노트, 팁 좋아요 기능 구현
- 좋아요를 누르고 눌렀던 좋아요를 취소 하는 기능 구현

## Changes 📝
- 레시피의 좋아요 기능을 구현했습니다.
- 노트의 좋아요 기능을 구현했습니다.
- 팁의 좋아요 기능을 구현했습니다. 추가적으로 팁 UI 도 개선 하였습니다.
- mutation 을 위한 레시피, 노트, 팁의 custom hook 을 만들어 놓았는데 refactoring 시 필요한 상태관리도 포함하여 해당 컴포넌트 내부 코드를 더 줄일수 있는 방법을 고민중입니다. custom hook 은 코드를 줄일때 유용하게 쓸수있는데 현재로서는 mutation 객체를 담은 파일로 사용되지 않는것 같습니다. 고민해 보겠습니다.
- 좋아요를 위한 useEffect를 사용한 훅이 조금 반복적인 면이 있는데 이부분도 refactoring 시 custom hook 로 만드는것이 낫지 않나 생각됩니다. 기한을 고려하여 일단 먼저 기능 구현을 우선적으로 했습니다.
- (참고사항) 현재 노트의 좋아요는 데이터 상으로는 작동이 잘 되지만 화면상에 바로 업데이트가 되지 않는 문제가 있습니다. 새로고침 하거나 다른 컴포넌트를 mount 시켰다가 다시 돌아오면 화면상에도 업데이트가 되는데 Note component 가 mount 된 상태에서는 화면상으로는 좋아요가 달라지는것이 보이지를 않습니다. Recipe 와 Tip 은 React Query 사용을 통해 query invalidation 을 이용하여 작업이 성공했을 시 re-fetch 를 진행 시켜서 DB의 상태가 바로 업데이트 됩니다. 하지만 Note 는 props 방식으로 업데이트가 되는데 내부 로직도 문제가 있을 수 있지만 기본적으로 DB 상태를 실시간 업데이트 하는것은 한계가 있어 보이기도 합니다. 계속 시도해 보겠습니다.

## Screennshot 📷
![image](https://user-images.githubusercontent.com/61281531/173205582-2edbbbfa-794b-4190-bde2-8c4498557447.png)
![image](https://user-images.githubusercontent.com/61281531/173205589-bc42c212-4e2e-4c22-b6f5-df0be5181a03.png)
![image](https://user-images.githubusercontent.com/61281531/173205570-f8495078-38ec-4817-b92f-768a8dbdc7cc.png)
![image](https://user-images.githubusercontent.com/61281531/173205604-732751af-7182-4c15-9ecc-e0fa1526a9da.png)

## Test Checklist ✅
- 레시피, 노트, 팁의 좋아요 기능 테스트가 필요합니다. 좋아요가 취소되고 다시 좋아요를 누르고 할 수 있어야합니다.