### PR TITLE
feat: note and tips delete functionality

### DIFF
--- a/src/api/noteApi.js
+++ b/src/api/noteApi.js
@@ -41,7 +41,7 @@ export const cancelNoteLike = async (note) => {
   return response.data;
 };
 
-export const deleteNote = async (note_id) => {
+export const deleteNote = async ({ note_id }) => {
   const response = await fetchApi.delete(`/api/notes/${note_id}`);
   return response.data;
 };

--- a/src/api/tipApi.js
+++ b/src/api/tipApi.js
@@ -42,8 +42,8 @@ export const cancelTipLike = async (tip) => {
   return response.data;
 };
 
-export const deleteTip = async (tip_id) => {
-  const response = await fetchApi.delete(`/api/tips/${tip_id}`, tip_id);
+export const deleteTip = async ({ tip_id }) => {
+  const response = await fetchApi.delete(`/api/tips/${tip_id}`);
 
   return response.data;
 };

--- a/src/config/youtubeConfig.js
+++ b/src/config/youtubeConfig.js
@@ -1,0 +1,4 @@
+export const videoOptions = {
+  height: "390",
+  width: "640",
+};

--- a/src/pages/PageSingleRecipe.MyNote.js
+++ b/src/pages/PageSingleRecipe.MyNote.js
@@ -5,9 +5,8 @@ import { getIngredients, getUnits } from "../api/foodApi";
 import useNoteMutation from "../hooks/note-mutation-hook";
 import Ingredients from "./PageSingleRecipe.Ingredients";
 import { isLikedCheck } from "../utils/likeHelper";
-import { getNote } from "../api/noteApi";
 
-const Note = ({ loginUserInfo, note, recipeId }) => {
+const Note = ({ loginUserInfo, note, recipeId, openNoteList }) => {
   const { data: ingredients } = useQuery("ingredients", getIngredients);
   const { data: units } = useQuery("units", getUnits);
   const {
@@ -83,6 +82,7 @@ const Note = ({ loginUserInfo, note, recipeId }) => {
       content,
       visibility: isVisibile,
     });
+    openNoteList("notes");
   };
 
   const updateNoteHandler = () => {
@@ -95,7 +95,10 @@ const Note = ({ loginUserInfo, note, recipeId }) => {
   };
 
   const deleteNoteHandler = () => {
-    deleteNoteMutation.mutate();
+    deleteNoteMutation.mutate({
+      note_id: note._id,
+    });
+    openNoteList("notes");
   };
 
   const openModalHandler = () => {
@@ -145,9 +148,9 @@ const Note = ({ loginUserInfo, note, recipeId }) => {
 
             <IngredientsList>
               {totalIngredients.length &&
-                totalIngredients.map((ingredient) => {
+                totalIngredients.map((ingredient, index) => {
                   return (
-                    <IngredientsCard>
+                    <IngredientsCard key={ingredient._id}>
                       <div>{`${ingredient.split("-")[0]} ${
                         ingredient.split("-")[1]
                       }${ingredient.split("-")[2]}`}</div>

--- a/src/pages/PageSingleRecipe.Notes.js
+++ b/src/pages/PageSingleRecipe.Notes.js
@@ -1,5 +1,5 @@
 import { dateOptions } from "../config/dateConfig";
-import { sortDescendingByUpdatedAt } from "../utils/sortHelper";
+import { sortDescendingByCreatedAt } from "../utils/sortHelper";
 import styled from "styled-components";
 
 const Notes = ({ notes, openNote, changeNote }) => {
@@ -12,7 +12,7 @@ const Notes = ({ notes, openNote, changeNote }) => {
 
   return (
     <NotesContainer>
-      {sortDescendingByUpdatedAt(notes).map((note) => {
+      {sortDescendingByCreatedAt(notes).map((note) => {
         return (
           note.visibility && (
             <NotesCard key={note._id} id={note._id} onClick={clickNoteHandler}>

--- a/src/pages/PageSingleRecipe.Tips.js
+++ b/src/pages/PageSingleRecipe.Tips.js
@@ -1,7 +1,8 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useQuery } from "react-query";
-import styled from "styled-components";
+import styled, { keyframes } from "styled-components";
 import { getTipsByRecipeId } from "../api/tipApi";
+import { dateOptions } from "../config/dateConfig";
 import useTipMutation from "../hooks/tip-mutation-hook";
 import { isLikedCheck } from "../utils/likeHelper";
 import { sortDescendingByUpdatedAt } from "../utils/sortHelper";
@@ -17,22 +18,37 @@ const Tips = ({ loginUserInfo, recipeId }) => {
       {tips?.length &&
         sortDescendingByUpdatedAt(tips).map((tip) => {
           return (
-            <TipCard key={tip._id} loginUserInfo={loginUserInfo} tip={tip} />
+            <TipCard
+              key={tip._id}
+              loginUserInfo={loginUserInfo}
+              tip={tip}
+              isMyTip={tip.creator.email === loginUserInfo.email}
+            />
           );
         })}
     </TipsContainer>
   );
 };
 
-const CreateTip = ({ loginUserInfo, recipeId }) => {
+const CreateTip = ({
+  loginUserInfo,
+  recipeId,
+  isEditing,
+  closeEditMode,
+  tip,
+}) => {
   const [tipInput, setTipInput] = useState("");
-  const { createTipMutation } = useTipMutation();
+  const { createTipMutation, updateTipMutation } = useTipMutation();
+  const inputElement = useRef();
 
   const inputTipHandler = (event) => {
     setTipInput(event.target.value);
   };
 
   const clickCancelTipHandler = () => {
+    if (isEditing) {
+      closeEditMode();
+    }
     setTipInput("");
   };
 
@@ -42,7 +58,17 @@ const CreateTip = ({ loginUserInfo, recipeId }) => {
       relatedRecipe: recipeId,
       content: tipInput,
     });
+    inputElement.current.value = "";
+    setTipInput("");
+  };
 
+  const clickUpdateTipHandler = () => {
+    updateTipMutation.mutate({
+      tip_id: tip._id,
+      content: tipInput,
+    });
+    closeEditMode();
+    inputElement.current.value = "";
     setTipInput("");
   };
 
@@ -53,21 +79,29 @@ const CreateTip = ({ loginUserInfo, recipeId }) => {
         <TipInput
           placeholder="꿀팁 추가..."
           onChange={inputTipHandler}
-          value={tipInput}
+          defaultValue={isEditing ? tip.content : tipInput}
+          ref={inputElement}
         />
         <TipButtonBox>
           <TipButton onClick={clickCancelTipHandler}>취소</TipButton>
-          <TipButton onClick={clickCreateTipHandler}>등록</TipButton>
+          <TipButton
+            onClick={isEditing ? clickUpdateTipHandler : clickCreateTipHandler}
+          >
+            {isEditing ? "수정" : "등록"}
+          </TipButton>
         </TipButtonBox>
       </TipInputContainer>
     </TipsCardContainer>
   );
 };
 
-const TipCard = ({ loginUserInfo, tip }) => {
-  const { updateTipLikeMutation, cancelTipLikeMutation } = useTipMutation();
+const TipCard = ({ loginUserInfo, tip, isMyTip }) => {
+  const { updateTipLikeMutation, cancelTipLikeMutation, deleteTipMutation } =
+    useTipMutation();
   const [isLiked, setIsLiked] = useState(false);
   const [likeOrDislike, setLikeOrDislike] = useState("");
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
 
   useEffect(() => {
     const isAlreadyLiked = isLikedCheck(loginUserInfo.email, tip.liked);
@@ -100,28 +134,130 @@ const TipCard = ({ loginUserInfo, tip }) => {
     }
   };
 
-  return (
-    <TipsCardContainer>
-      <TipProfileImg src="" alt="tip-owner-profile-image" />
-      <TipContent>
-        <TipContentInfo>
-          {tip.creator.nickname} / {tip.creator.updatedAt}
-        </TipContentInfo>
-        <TipContentDeatil>{tip.content}</TipContentDeatil>
-      </TipContent>
-      <TipPreference>
-        <button name="like" onClick={clickLikeHandler}>
-          👍 {tip.liked.length}
-        </button>
-        <button name="dislike" onClick={clickLikeHandler}>
-          👎 {tip.disliked.length}
-        </button>
-      </TipPreference>
-    </TipsCardContainer>
-  );
+  const clickEditHandler = () => {
+    if (isEditing) {
+      clickEditModal();
+    }
+    setIsEditing(!isEditing);
+  };
+
+  const clickDeleteHandler = () => {
+    deleteTipMutation.mutate({
+      tip_id: tip._id,
+    });
+  };
+
+  const clickEditModal = () => {
+    setIsModalOpen(!isModalOpen);
+  };
+
+  if (isEditing) {
+    return (
+      <CreateTip
+        loginUserInfo={loginUserInfo}
+        recipeId={tip.relatedRecipe._id}
+        isEditing={isEditing}
+        closeEditMode={clickEditHandler}
+        tip={tip}
+      />
+    );
+  } else {
+    return (
+      <TipsCardContainer>
+        <TipProfileImg src="" alt="tip-owner-profile-image" />
+        <TipContent>
+          <TipContentInfo>
+            {tip.creator.nickname} /{" "}
+            {new Date(tip.creator.updatedAt).toLocaleDateString(
+              "ko-KR",
+              dateOptions
+            )}
+          </TipContentInfo>
+          <TipContentDeatil>{tip.content}</TipContentDeatil>
+        </TipContent>
+        <div></div>
+        <TipPreference>
+          {isMyTip && (
+            <TipEditButton onClick={clickEditModal}>...</TipEditButton>
+          )}
+          {isModalOpen && (
+            <TipEditContainer>
+              <div onClick={clickEditHandler}>수정</div>
+              <div onClick={clickDeleteHandler}>삭제</div>
+            </TipEditContainer>
+          )}
+          <button name="like" onClick={clickLikeHandler}>
+            👍 {tip.liked.length}
+          </button>
+          <button name="dislike" onClick={clickLikeHandler}>
+            👎 {tip.disliked.length}
+          </button>
+        </TipPreference>
+      </TipsCardContainer>
+    );
+  }
 };
 
 export default Tips;
+
+const TipEditButton = styled.button``;
+const TipLikeButton = styled.button``;
+const TipDislikeButton = styled.button``;
+
+const fadeIn = keyframes`
+  from {
+    transform: scale(0.25);
+    opacity: 0;
+  }
+
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+`;
+
+const TipPreference = styled.div`
+  position: relative;
+  min-width: 60px;
+  height: 100%;
+  display: flex;
+  align-items: center;
+`;
+
+const TipEditContainer = styled.div`
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  background-color: #dee2e6;
+  right: 115%;
+  top: 25%;
+  padding: 0 5px;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+
+  div {
+    height: 30%;
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+  }
+
+  div {
+    height: 30%;
+    display: flex;
+    align-items: center;
+  }
+
+  div:nth-child(2) {
+    border-bottom: 1px solid black;
+  }
+
+  animation: ${fadeIn} 0.15s ease-out;
+`;
 
 const TipsContainer = styled.div`
   display: flex;
@@ -164,13 +300,6 @@ const TipContentInfo = styled.div`
 `;
 const TipContentDeatil = styled.div`
   height: 70%;
-  display: flex;
-  align-items: center;
-`;
-
-const TipPreference = styled.div`
-  min-width: 60px;
-  height: 100%;
   display: flex;
   align-items: center;
 `;

--- a/src/pages/PageSingleRecipe.js
+++ b/src/pages/PageSingleRecipe.js
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { useParams } from "react-router";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
-
+import YouTube from "react-youtube";
 import Notes from "./PageSingleRecipe.Notes";
 import Tips from "./PageSingleRecipe.Tips";
 import Note from "./PageSingleRecipe.MyNote";
@@ -10,6 +10,7 @@ import { useQuery } from "react-query";
 import { getRecipe } from "../api/recipeApi";
 import useRecipeMutation from "../hooks/recipe-mutation-hook";
 import { isLikedCheck } from "../utils/likeHelper";
+import { videoOptions } from "../config/youtubeConfig";
 
 function PageSingleRecipe({ loginUserInfo, handleLogin }) {
   const [currentBoardPage, setBoardPage] = useState("notes");
@@ -91,8 +92,16 @@ function PageSingleRecipe({ loginUserInfo, handleLogin }) {
           </button>
         </NavigationPage>
         <VideoPlayer>
-          <Screen>스크린</Screen>
-          <Controller>컨트롤러</Controller>
+          <YouTube
+            videoId={recipe?.youtubeUrl.split("v=")[1].split("&")[0]}
+            id="youtube"
+            opts={{ height: "390", width: "640" }}
+          />
+          <Controller>
+            <button>재생/중지</button>
+            <button>{">>"}</button>
+            <button>{"<<"}</button>
+          </Controller>
         </VideoPlayer>
       </LeftSection>
       <RightSetction>
@@ -139,6 +148,7 @@ function PageSingleRecipe({ loginUserInfo, handleLogin }) {
               loginUserInfo={loginUserInfo}
               note={currentNote}
               recipeId={recipe_id}
+              openNoteList={setBoardPage}
             />
           )}
           {currentBoardPage === "myNote" && (
@@ -146,6 +156,7 @@ function PageSingleRecipe({ loginUserInfo, handleLogin }) {
               loginUserInfo={loginUserInfo}
               note={myNote}
               recipeId={recipe_id}
+              openNoteList={setBoardPage}
             />
           )}
         </BoardMain>

--- a/src/utils/sortHelper.js
+++ b/src/utils/sortHelper.js
@@ -2,10 +2,23 @@ exports.sortDescendingByUpdatedAt = (arrayData) => {
   const arrayDataCopy = arrayData.slice();
 
   arrayDataCopy.sort((a, b) => {
-    const updatedAtA = new Date(a.createdAt).getTime();
-    const updatedAtB = new Date(b.createdAt).getTime();
+    const updatedAtA = new Date(a.updatedAt).getTime();
+    const updatedAtB = new Date(b.updatedAt).getTime();
 
     return updatedAtB - updatedAtA;
+  });
+
+  return arrayDataCopy;
+};
+
+exports.sortDescendingByCreatedAt = (arrayData) => {
+  const arrayDataCopy = arrayData.slice();
+
+  arrayDataCopy.sort((a, b) => {
+    const createdAtA = new Date(a.createdAt).getTime();
+    const createdAtB = new Date(b.createdAt).getTime();
+
+    return createdAtB - createdAtA;
   });
 
   return arrayDataCopy;


### PR DESCRIPTION
## What is this PR? 🔍
- 노트와 꿀팁의 삭제 및 수정 기능을 구현. 추가로 팀원의 요청으로 임시로 Page Singe Recipe 에 유투브 시청 기능 구현
## Changes 📝
- 노트와 꿀팁의 삭제 기능을 구현 했습니다.
- 꿀팁의 수정 기능을 구현했습니다. 밑에 스샷을 보시면 아시겠지만 "..." 버튼을 통해 꿀팁을 수정 및 삭제 할수있고 이 기능은 현재 로그인한 사용자가 등록 한 팁만 기능을 사용할 수 있습니다. 수정 기능은 layout 을 만들어 주신 CreateNote 컴포넌트를 사용해 깔끔히 보여줄 수 있었습니다.
- 팀원의 요청으로 일단 PageSingleRecipe에서 유투브를 시청 할 수 있는 기능을 추가해놓았습니다. 
- tips 의 css도 수정이 좀 있었는데 원일님께서 구현해 놓으신 account modal 을 가지고 와서 구현 시도를 해보았는데 원일님 처럼 깔끔하지는 않은것 같습니다.

### Comments
- 노트 삭제는 분명히 되지만 이번에도 UI가 바로 업데이트 하지 못하는 문제가 발생합니다. Page Single Recipe를 나갔다 들어오면 업데이트가 되지만 삭제 버튼만 누르고 "내 노트" 를 누른다면 삭제된 노트가 여전히 보이는 문제가 있습니다. 수정 예정입니다.
- react-youtube 를 이용해 사용하고 해당 메서드와 컨트롤 기능은 추후 추가될 예정입니다.
- 현재 PageSingleRecipe.Tips 페이지가 CSS 를 포함하여 좀 비대해지는 면이 있습니다. Refactoring 시 분리를 해야될것 같습니다.

## Screennshot 📷
<img width="745" alt="image" src="https://user-images.githubusercontent.com/61281531/173230431-e853e5cb-e882-4575-8a3b-bd59a2611ff9.png">
<img width="755" alt="image" src="https://user-images.githubusercontent.com/61281531/173230445-fb0b3549-954c-4e4e-a408-298a401e80be.png">
<img width="745" alt="image" src="https://user-images.githubusercontent.com/61281531/173230485-71afb813-89bb-4462-a3f2-099cb61500f6.png">
![image](https://user-images.githubusercontent.com/61281531/173230987-1c5e9d64-dfa5-4fe6-9e20-66ab94fa73f4.png)

## Test Checklist ✅
- 꿀팁을 수정하면 가장 리스트의 맨 위로 올라가는 로직의 테스트가 필요합니다.
- 꿀팁 수정 시 해당 리스트 내에서 수정이 되어야 합니다.
- 노트를 삭제하고 난 후 "내 노트"를 열람 했을때 새로운 노트가 보여야 합니다.