### PR TITLE
build: proxy and backend url changed to new AWS deployed https url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "dotenv": "^16.0.1",
         "firebase": "^9.8.1",
         "http-proxy-middleware": "^2.0.6",
-        "lodash": "^4.17.21",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-query": "^3.39.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "typewriter-effect": "^2.18.2",
     "web-vitals": "^2.1.4"
   },
-  "proxy": "http://silvertownservernodejs-env.eba-e9i79esa.ap-northeast-2.elasticbeanstalk.com/",
+  "proxy": "https://api.silvertown-mojori.com/",
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",


### PR DESCRIPTION
## What is this PR? 🔍
- AWS backend URL HTTPS 로 변경
## Changes 📝
- GoDaddy 에서 도메인 구매
- AWS server URL https 로 변경 -> vercel env 에서 backend URL 아래 새로운 URL 로 변경 필요
- https://api.silvertown-mojori.com/
## Screennshot 📷
![image](https://user-images.githubusercontent.com/61281531/174131561-14b02a15-3edb-4033-b412-99930079a5cb.png)
## Test Checklist ✅
- N/A